### PR TITLE
Add GameOverScene for wall-case, body's-length-case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 all:
-	g++ src/GameScene.cpp src/Snake.cpp src/Stage.cpp src/myFunction.cpp src/ItemManager.cpp src/WaitingScene.cpp src/main.cpp -lncurses -o /tmp/a.out && /tmp/a.out
+	g++ src/GameScene.cpp src/GameOverScene.cpp src/Snake.cpp src/Stage.cpp src/myFunction.cpp src/ItemManager.cpp src/WaitingScene.cpp src/main.cpp -lncurses -o /tmp/a.out && /tmp/a.out

--- a/src/Fruit.h
+++ b/src/Fruit.h
@@ -9,16 +9,8 @@
 class Fruit : public Item
 {
 public:
-    int timeCheck = 0;
-    int maxwidth, maxheight;
-    std::vector<CharPosition> data;
-    bool eatFruit = false;
-
-    Fruit()
-    {
-        getmaxyx(stdscr, maxheight, maxwidth);
-        data.push_back(CharPosition(rand() % (maxwidth - 1) + 1, rand() % (maxheight - 1) + 1));
-    }
+    
+    Fruit() {}
     ~Fruit() {}
     void Print()
     {

--- a/src/GameOverScene.cpp
+++ b/src/GameOverScene.cpp
@@ -1,0 +1,48 @@
+#include "IScene.h"
+#include "GameScene.h"
+#include "Stage.h"
+#include "WaitingScene.h"
+#include <ncurses.h>
+#include <cstdlib>
+#include <ctime>
+#include <iostream>
+
+GameOverScene::GameOverScene(){
+    Stage *stage1;
+    stage1 = new Stage();
+    stage1->setNowStage(1);
+};
+GameOverScene::~GameOverScene(){}
+
+void GameOverScene::Update(){
+    if (AskUserToPlayAgain() == 'y')ChangeScene(new GameScene());
+}
+void GameOverScene::Render(){}
+
+// clear the screen and centre the cursor
+void GameOverScene::ClearCentre(float x, float y)
+{
+    initscr();
+    noecho();
+    getmaxyx(stdscr, maxheight, maxwidth);
+    move((maxheight / y), (maxwidth / x));
+}
+
+    // receive user confirmation
+int GameOverScene::UserInput()
+{
+    int UserInput = getch();
+    refresh();
+    endwin();
+    clear();
+
+    return UserInput;
+}
+
+    // print ask to play again
+int GameOverScene::AskUserToPlayAgain()
+{
+    ClearCentre(3.5, 2);
+    printw("Game Over....! Do you want to play game again? (y/n)");
+    return UserInput();
+}

--- a/src/GameOverScene.h
+++ b/src/GameOverScene.h
@@ -8,50 +8,20 @@
 class GameOverScene : public IScene
 {
 public:
-    int maxwidth, maxheight;
-    bool igo = false;
+    int maxwidth=94, maxheight=39;
 
-    GameOverScene(){};
-    ~GameOverScene(){};
+    GameOverScene();
+    ~GameOverScene();
 
-    void Update(){};
-    void Render(){};
+    void Update();
+    void Render();
 
     // clear the screen and centre the cursor
-    void ClearCentre(float x, float y)
-    {
-        clear(); // clear the screen if the game is played for the 2nd time
-        initscr();
-        noecho();
-        getmaxyx(stdscr, maxheight, maxwidth);
-        move((maxheight / y), (maxwidth / x));
-    }
+    void ClearCentre(float x, float y);
 
     // receive user confirmation
-    int UserInput()
-    {
-        int UserInput = getch();
-        refresh();
-        endwin();
-        clear();
-
-        return UserInput;
-    }
+    int UserInput();
 
     // print ask to play again
-    int AskUserToPlayAgain()
-    {
-        ClearCentre(2.5, 2.5);
-        printw("Do you want to play again? (y/n)");
-        return UserInput();
-    }
-
-    bool isGameOver()
-    {
-        return igo;
-    }
-    bool setGameover(bool set)
-    {
-        igo = set;
-    }
+    int AskUserToPlayAgain();
 };

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -31,7 +31,6 @@ GameScene::GameScene()
 GameScene::~GameScene()
 {
 	nodelay(stdscr, false);
-	getch();
 	endwin();
 }
 
@@ -68,27 +67,27 @@ void GameScene::Render()
 // draw the game window
 void GameScene::DrawWindow()
 {
-	for (int32 i = 0; i < maxwidth; i++) // draws top
+	for (int32 i = 0; i < 94; i++) // draws top
 	{
 		move(0, i);
 		addch(edgechar);
 	}
 
-	for (int32 i = 0; i < maxwidth; i++) // draws bottom
+	for (int32 i = 0; i < 94; i++) // draws bottom
 	{
-		move(maxheight - 2, i);
+		move(39 - 2, i);
 		addch(edgechar);
 	}
 
-	for (int32 i = 0; i < maxheight - 1; i++) // draws left side
+	for (int32 i = 0; i < 39 - 1; i++) // draws left side
 	{
 		move(i, 0);
 		addch(edgechar);
 	}
 
-	for (int32 i = 0; i < maxheight - 1; i++) // draws right side
+	for (int32 i = 0; i < 39 - 1; i++) // draws right side
 	{
-		move(i, maxwidth - 1);
+		move(i, 94 - 1);
 		addch(edgechar);
 	}
 	return;

--- a/src/GameScene.h
+++ b/src/GameScene.h
@@ -15,7 +15,8 @@ using int32 = int;
 class GameScene : public IScene
 {
 public:
-	int32 score, maxwidth, maxheight;
+	int32 score;
+	int32 maxwidth = 94, maxheight = 39;
 
 	char edgechar;
 

--- a/src/Item.h
+++ b/src/Item.h
@@ -7,13 +7,13 @@ class Item
 {
 public:
     int timeCheck = 0;
-    int maxwidth, maxheight;
     std::vector<CharPosition> data;
     bool eatPoison = false;
+    bool eatFruit = false;
 
     Item()
     {
-        getmaxyx(stdscr, maxheight, maxwidth);
+        int maxwidth= 94, maxheight=39;
         data.push_back(CharPosition(rand() % (maxwidth - 1) + 1, rand() % (maxheight - 1) + 1));
     }
     virtual void Print() = 0;

--- a/src/Snake.cpp
+++ b/src/Snake.cpp
@@ -1,4 +1,7 @@
 #include "CharPosition.h"
+#include "myFunction.h"
+#include "GameOverScene.h"
+#include "IScene.h"
 #include "Snake.h"
 
 Snake::Snake()
@@ -27,7 +30,12 @@ void Snake::initBody()
 
 void Snake::Update()
 {
-	int32 KeyPressed = getch();
+	//  ths snake's size below 3. Chanege GameScene to GameOverScene
+	int32 KeyPressed;
+	if (entire.size() < 3 || (entire[0].x <= 0 || entire[0].x >= 93) || (entire[0].y >= 38 || entire[0].y <= 0)){
+		ChangeScene(new GameOverScene());
+	}
+	if (KeyPressed >= 3)KeyPressed = getch();
 	switch (KeyPressed)
 	{
 	case KEY_LEFT:
@@ -77,6 +85,7 @@ void Snake::Update()
 	{
 		entire.insert(entire.begin(), CharPosition(entire[0].x, entire[0].y + 1));
 	}
+
 	refresh();
 }
 
@@ -104,11 +113,12 @@ void Snake::Render()
 		entire.pop_back(); // add empty ch to remove last character
 		refresh();
 	}
-	if (entire.size() == 3)
-		;
+	
+	
 	// move to the new CharPosition coordinates
 	move(entire[0].y, entire[0].x);
 	addch(partchar); // add a new head
+
 	refresh();
 }
 

--- a/src/Snake.h
+++ b/src/Snake.h
@@ -2,6 +2,9 @@
 #include <ncurses.h>
 #include <vector>
 #include "CharPosition.h"
+#include "myFunction.h"
+#include "GameOverScene.h"
+#include "IScene.h"
 #include "IObject.h"
 
 using int32 = int;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,6 @@ This is handling all user interaction. For game logic, please see fSnakeGame.h.
 #include <ncurses.h>
 #include <cstdlib>
 #include <ctime>
-
 #include "WaitingScene.h"
 #include "GameOverScene.h"
 #include "myFunction.h"


### PR DESCRIPTION
:paperclip: 게임 오버되는 케이스들을 구현함.

:heavy_check_mark: 추가된 기능
- snake body의 length가 3미만이면 Game Over
- snake head가 벽에 부딪히면 Game Over

:heavy_multiplication_x: 문제점
- GameOverScene으로 넘어갈 때, snake-game의 WaitingScene으로 넘어가려면 키를 입력해야됨.
- item들을 map에 scatter하는 과정에서 map 밖에 생성이 됨.

