### PR TITLE
Add GetElapsedTime to project structure

### DIFF
--- a/src/Format.h
+++ b/src/Format.h
@@ -40,6 +40,6 @@ public:
     }
     ~Format() {}
     void Print() {}
-    void Update() {}
+    void Update(float eTime) {}
     void Render() {}
 };

--- a/src/GameOverScene.cpp
+++ b/src/GameOverScene.cpp
@@ -16,7 +16,7 @@ GameOverScene::GameOverScene()
 };
 GameOverScene::~GameOverScene() {}
 
-void GameOverScene::Update()
+void GameOverScene::Update(float eTime)
 {
     char answer = AskUserToPlayAgain();
 

--- a/src/GameOverScene.h
+++ b/src/GameOverScene.h
@@ -13,7 +13,7 @@ public:
     GameOverScene();
     ~GameOverScene();
 
-    void Update();
+    void Update(float eTime);
     void Render();
 
     // clear the screen and centre the cursor

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -47,14 +47,17 @@ void GameScene::InitGameWindow()
 	return;
 }
 
-void GameScene::Update()
+void GameScene::Update(float eTime)
 {
-	stage->Update();
-	snake->Update();
-	itemManager->Update();
+	stage->Update(eTime);
+	snake->Update(eTime);
+	itemManager->Update(eTime);
 	itemManager->GetItem(*snake);
 	snake->EatItem(itemManager->getEatFruit(), itemManager->getEatPoison());
-
+    
+    //* float eTime test code *//
+    // move((maxheight-2)/2,(maxwidth-5)/2);
+    // printw("%f",eTime);
 	usleep(100000);
 }
 

--- a/src/GameScene.h
+++ b/src/GameScene.h
@@ -42,7 +42,7 @@ public:
 	// bool GetsFruit();
 	// bool GetsPoisonItem();
 
-	void Update();
+	void Update(float eTime);
 	void Render();
 
 	// void UpdateRunning(float eTime);

--- a/src/IObject.h
+++ b/src/IObject.h
@@ -4,6 +4,6 @@ class IObject
 public:
 	IObject() {}
 	virtual ~IObject() {}
-	virtual void Update() = 0;
+	virtual void Update(float eTime) = 0;
 	virtual void Render() = 0;
 };

--- a/src/IScene.h
+++ b/src/IScene.h
@@ -6,5 +6,5 @@ public:
 	IScene() {}
 	virtual ~IScene() {}
 	virtual void Render() = 0;
-	virtual void Update() = 0;
+	virtual void Update(float eTime) = 0;
 };

--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -18,7 +18,7 @@ void ItemManager::Render()
 {
 }
 
-void ItemManager::Update()
+void ItemManager::Update(float eTime)
 {
     fruit.timeCheck = fruit.timeCheck % 100;
     poison.timeCheck = poison.timeCheck % 100;

--- a/src/ItemManager.h
+++ b/src/ItemManager.h
@@ -21,7 +21,7 @@ public:
     ~ItemManager();
 
     void Render();
-    void Update();
+    void Update(float eTime);
     void PositionItem(std::string check);
     void GetItem(Snake s);
     void CheckFruit();

--- a/src/Snake.cpp
+++ b/src/Snake.cpp
@@ -29,7 +29,7 @@ void Snake::initBody()
 	}
 }
 
-void Snake::Update()
+void Snake::Update(float eTime)
 {
 	//  ths snake's size below 3. Chanege GameScene to GameOverScene
 	int32 KeyPressed;

--- a/src/Snake.h
+++ b/src/Snake.h
@@ -23,7 +23,7 @@ public:
 	bool eatFruit = false;
 	bool eatPoison = false;
 
-	void Update();
+	void Update(float eTime);
 	void Render();
 	void initBody();
 	void EatItem(bool fruit, bool poison);

--- a/src/Stage.cpp
+++ b/src/Stage.cpp
@@ -10,7 +10,7 @@ Stage::Stage(){
 Stage::~Stage(){
 }
 
-void Stage::Update(){
+void Stage::Update(float eTime){
     
     if(clear){
         refresh();

--- a/src/Stage.h
+++ b/src/Stage.h
@@ -16,6 +16,6 @@ public:
 		this->nowStage = nowStage;
 	}
 
-	void Update();
+	void Update(float eTime);
 	void Render();
 };

--- a/src/WaitingScene.cpp
+++ b/src/WaitingScene.cpp
@@ -15,7 +15,7 @@ WaitingScene::~WaitingScene()
 {
 }
 
-void WaitingScene::Update()
+void WaitingScene::Update(float eTime)
 {
     char answer = IsUserReady();
 

--- a/src/WaitingScene.h
+++ b/src/WaitingScene.h
@@ -15,7 +15,7 @@ public:
 	WaitingScene();
 	~WaitingScene();
 
-	void Update();
+	void Update(float eTime);
 	void Render();
 
 	void ClearCentre(float x, float y);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,7 @@ int32 main()
 	Init();
 	do
 	{
-		Update();
+		Update(GetElapsedTime());
 		Render();
 	} while (true);
 	// (AskUserToPlayAgain() == 'y');

--- a/src/myFunction.cpp
+++ b/src/myFunction.cpp
@@ -1,20 +1,23 @@
 #include "myFunction.h"
 #include "WaitingScene.h"
 
-using namespace std;
+
 IScene *nowScene;
 bool lkey[256],rkey[256];
 
+std::chrono::steady_clock::time_point startTime;
+
 void Init(){
+    startTime = std::chrono::steady_clock::now();
 	nowScene = new WaitingScene();
 	// QueryPerformanceCounter(&LInterval);
 	// QueryPerformanceFrequency(&Frequency);
 	// for(int i=0;i<256;i++) rkey[i] = lkey[i] = false;
 }
 
-void Update(){
+void Update(float eTime){
 	// UpdateKeyState();
-	nowScene->Update();
+	nowScene->Update(eTime);
 }
 
 void Render(){
@@ -25,15 +28,12 @@ void Destroy(){
 	delete nowScene;
 }
 
-// float GetElapsedTime(){
-// 	QueryPerformanceCounter(&RInterval);
-// 	__int64 Interval = (RInterval.QuadPart - LInterval.QuadPart);
-
-// 	float eTime = (double)Interval/(double)Frequency.QuadPart;
-
-// 	LInterval = RInterval;
-// 	return eTime;
-// }
+float GetElapsedTime(){
+    auto endTime = std::chrono::steady_clock::now();
+    std::chrono::duration<float> elapsed_seconds = endTime-startTime;
+	float eTime = (float)elapsed_seconds.count();
+	return eTime;
+}
 
 // void UpdateKeyState()
 // {
@@ -50,8 +50,9 @@ void Destroy(){
 // 	if(lkey[key]==true && rkey[key]==false) return -1;
 // 	return 0;
 // }
-void ChangeScene(IScene *p,bool nowSceneErase)
-{
+
+
+void ChangeScene(IScene *p,bool nowSceneErase){
 	if(nowSceneErase) delete nowScene;
 	nowScene = p;
 }

--- a/src/myFunction.h
+++ b/src/myFunction.h
@@ -1,13 +1,15 @@
 #pragma once
 #include "IScene.h"
+#include <chrono>
 #include <iostream>
+
 using namespace std;
 
 void Init();
-void Update(); //Elapsed Time
+void Update(float eTime); //Elapsed Time
 void Render();
 void Destroy();
-// float GetElapsedTime();
+float GetElapsedTime();
 // void UpdateKeyState();
 // int MyKeyState(int key);
 void ChangeScene(IScene *p, bool nowSceneErase = true);


### PR DESCRIPTION
Changes proposed in this pull request: 
* IObject 또는 IScene을 상속받는 object는 Update 시 eTime을 이용해 프로그램 실행시간을 받아올 수 있습니다.

Example in this pull request:
``` c++
void GameScene::Update(float eTime)
{
	stage->Update(eTime);
	snake->Update(eTime);
	itemManager->Update(eTime);
	itemManager->GetItem(*snake);
	snake->EatItem(itemManager->getEatFruit(), itemManager->getEatPoison());
    
        //* float eTime test code *//
        move((maxheight-2)/2,(maxwidth-5)/2);
        printw("%f",eTime);
	usleep(100000);
}
