### PR TITLE
[Feature/gate] Fix errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 all:
-	g++ src/GameScene.cpp src/GameOverScene.cpp src/Snake.cpp src/Stage.cpp src/myFunction.cpp src/WallManager.cpp src/ItemManager.cpp src/MapManager.cpp src/WaitingScene.cpp src/Item.cpp src/main.cpp -lncurses -o /tmp/a.out && /tmp/a.out
+	g++ src/GameScene.cpp src/GameOverScene.cpp src/Snake.cpp src/Stage.cpp src/myFunction.cpp src/WallManager.cpp src/ItemManager.cpp src/MapManager.cpp src/WaitingScene.cpp src/GateManager.cpp src/Item.cpp src/main.cpp -lncurses -o /tmp/a.out && /tmp/a.out

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -66,9 +66,11 @@ void GameScene::ProcessCollision(){
     int x=snake->GetHead().x;
     switch(mapManager->data[y][x]){
           case '5':
+            itemManager->DeleteCollisionData(y, x);
             snake->Grow();
             break;
           case '6':
+            itemManager->DeleteCollisionData(y, x);
             snake->Shrink();
             break;
           case '7':

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -24,15 +24,19 @@ GameScene::GameScene()
 	srand(time(NULL));
 
 	
-	// wallManager = new WallManager();
 	
     player=new Player();
+    
+    //mapManager를 먼저 생성시켜줘야함
     mapManager=new MapManager();
     mapManager->Load();
     
     snake = new Snake();
     itemManager = new ItemManager();
-
+	gateManager = new GateManager();
+    
+    
+    
     // format = new Format();
 
 
@@ -94,11 +98,12 @@ void GameScene::Update(float eTime)
 
     snake->Update(eTime);
 	itemManager->Update(eTime);
+	gateManager->Update(eTime);
+
     if(snake->IsCollision()){
         ProcessCollision();
     }
     
-	// wallManager->Update(eTime);
     
     
 	// itemManager->GetItem(*snake);

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -4,7 +4,7 @@
 #include "ItemManager.h"
 #include "myFunction.h"
 #include "IObject.h"
-
+#include "Player.h"
 #include "MapManager.h"
 
 #include <unistd.h>
@@ -16,6 +16,7 @@ extern Stage *stage;
 using int32 = int;
 
 MapManager * mapManager;
+Player * player;
 
 
 GameScene::GameScene()
@@ -24,12 +25,13 @@ GameScene::GameScene()
 
 	
 	// wallManager = new WallManager();
-	// itemManager = new ItemManager();
-    
+	
+    player=new Player();
     mapManager=new MapManager();
     mapManager->Load();
     
     snake = new Snake();
+    itemManager = new ItemManager();
 
     // format = new Format();
 
@@ -41,6 +43,7 @@ GameScene::GameScene()
 
 GameScene::~GameScene()
 {
+    //delete mapManager;
 	nodelay(stdscr, false);
 	endwin();
 }
@@ -57,11 +60,42 @@ void GameScene::InitGameWindow()
 	return;
 }
 
+
+void GameScene::ProcessCollision(){
+    int y=snake->GetHead().y;
+    int x=snake->GetHead().x;
+    switch(mapManager->data[y][x]){
+          case '5':
+            snake->Grow();
+            break;
+          case '6':
+            snake->Shrink();
+            break;
+          case '7':
+            break;
+    }
+}
+
+
+
 void GameScene::Update(float eTime)
 {
 	// stage->Update(eTime);
-	snake->Update(eTime);
-	// itemManager->Update(eTime);
+    
+    if(snake->isDied){
+        ChangeScene(new GameOverScene());
+    }
+    
+    player->SetLengthScore(snake->entire.size());
+    
+    
+
+    snake->Update(eTime);
+	itemManager->Update(eTime);
+    if(snake->IsCollision()){
+        ProcessCollision();
+    }
+    
 	// wallManager->Update(eTime);
     
     
@@ -75,35 +109,37 @@ void GameScene::Update(float eTime)
 }
 
 void GameScene::Render(){
-     char (*data)[WIDTH]=(char(*)[WIDTH])mapManager->GetData();
+    
+    mvaddch(0, maxwidth / 5 * 4 + 4, (char)(player->lengthScore+48));
+    char (*data)[WIDTH]=(char(*)[WIDTH])mapManager->GetData();
     for(int i = 0; i < HEIGHT; i++){
       for(int j = 0; j < WIDTH; j++){
         switch(data[i][j]){
-          case 48:
+          case '0':
             mvaddch(i, j, ' ');
             break;
-          case 49:
+          case '1':
             mvaddch(i, j, '-');
             break;
-          case 50:
+          case '2':
             mvaddch(i, j, 'X');
             break;
-          case 51:
+          case '3':
             mvaddch(i, j, 'H');
             break;
-          case 52:
+          case '4':
             mvaddch(i, j, 'B');
             break;
-          case 53:
+          case '5':
             mvaddch(i, j, 'G');
             break;
-          case 54:
+          case '6':
             mvaddch(i, j, 'P');
             break;
-          case 55:
+          case '7':
             mvaddch(i, j, '?');
             break;
-          case 57:
+          case '8':
             mvaddch(i, j, ' ');
           }
      }

--- a/src/GameScene.h
+++ b/src/GameScene.h
@@ -48,6 +48,7 @@ public:
 
 	void Update(float eTime);
 	void Render();
+    void ProcessCollision();
 
 	// void UpdateRunning(float eTime);
 	void UpdateGameover(float eTime);

--- a/src/GameScene.h
+++ b/src/GameScene.h
@@ -4,7 +4,7 @@
 #include "Stage.h"
 #include "Snake.h"
 #include "ItemManager.h"
-#include "WallManager.h"
+#include "GateManager.h"
 #include "Format.h"
 #include <iostream>
 #include <vector>
@@ -29,7 +29,7 @@ public:
 	~GameScene();
 	Snake *snake;
 	ItemManager *itemManager;
-	WallManager *wallManager;
+	GateManager *gateManager;
     
 	Format *format;
 

--- a/src/GateManager.cpp
+++ b/src/GateManager.cpp
@@ -2,35 +2,33 @@
 #include <ctime>
 #include <string>
 #include "Snake.h"
-#include "Item.h"
-#include "ItemManager.h"
+#include "Gate.h"
+#include "GateManager.h"
 #include "GameScene.h"
 
 extern MapManager * mapManager;
 
 
 
-ItemManager::ItemManager()
-{
-    getmaxyx(stdscr, maxheight, maxwidth);
+GateManager::GateManager(){
 }
 
-ItemManager::~ItemManager()
+GateManager::~GateManager()
 {
 }
 
-void ItemManager::Render(){
+void GateManager::Render(){
 
 }
 
-bool isExceedTime(Item item, float eTime){
-    if(eTime-item.dropTime>5){
+bool isExceedTime(Gate Gate, float eTime){
+    if(eTime-Gate.dropTime>5){
         return true;
     }
     return false;
 }
 
-void ItemManager::DeleteCollisionData(int y, int x){
+void GateManager::DeleteCollisionData(int y, int x){
     
     int target;
     
@@ -43,15 +41,15 @@ void ItemManager::DeleteCollisionData(int y, int x){
     
 }
 
-void ItemManager::Update(float eTime){
+void GateManager::Update(float eTime){
     int * temp=new int[data.size()];
-    vector<Item>::iterator iter;
+    vector<Gate>::iterator iter;
     
     
-    //item drop
+    //Gate drop
     if(eTime-lastDropTime>DROP_INTERVAL){
-        PositionItem("poison",eTime);
-        PositionItem("fruit",eTime);
+        PositionGate("poison",eTime);
+        PositionGate("fruit",eTime);
         lastDropTime=eTime;
     }
     
@@ -78,17 +76,17 @@ void ItemManager::Update(float eTime){
     
 }
 
-void ItemManager::PositionItem(std::string check, float eTime)
+void GateManager::PositionGate(std::string check, float eTime)
 {
     if (check == "fruit"){
-        data.push_back(Item("fruit",eTime));
+        data.push_back(Gate("fruit",eTime));
     }
     else if (check == "poison"){
-        data.push_back(Item("poison",eTime));
+        data.push_back(Gate("poison",eTime));
     }
 }
 
-void ItemManager::PushData(){
+void GateManager::PushData(){
     for (int32 i = 0; i < data.size(); i++){
         if(data[i].type=="fruit"){
             mapManager->PatchData(data[i].position.y, data[i].position.x, '5');
@@ -103,16 +101,3 @@ void ItemManager::PushData(){
         }
 	}
 }
-
-// void ItemManager::GetItem(Snake s)
-// {
-//     if (s.entire[0].x == fruit.data[0].x && s.entire[0].y == fruit.data[0].y)
-//         fruit.eatFruit = true;
-//     else
-//         fruit.eatFruit = false;
-
-//     if (s.entire[0].x == poison.data[0].x && s.entire[0].y == poison.data[0].y)
-//         poison.eatPoison = true;
-//     else
-//         poison.eatPoison = false;
-// }

--- a/src/GateManager.cpp
+++ b/src/GateManager.cpp
@@ -9,6 +9,20 @@
 extern MapManager * mapManager;
 
 
+CharPosition GateManager::getRandPosition(){
+    CharPosition temp;
+    while(1){
+        int x=rand() % (WIDTH);
+        int y=rand() % (HEIGHT);
+        if(mapManager->data[y][x]=='1'){
+            temp.x=x;
+            temp.y=y;
+            break;
+        }
+    }
+    return temp;
+}
+
 
 GateManager::GateManager(){
 }
@@ -21,83 +35,60 @@ void GateManager::Render(){
 
 }
 
-bool isExceedTime(Gate Gate, float eTime){
-    if(eTime-Gate.dropTime>5){
-        return true;
-    }
-    return false;
-}
+// CharPosition GateManager::getNextGate(){
+    
+// }
 
-void GateManager::DeleteCollisionData(int y, int x){
-    
-    int target;
-    
-    for(int i=0;i<data.size();i++){
-        if(data[i].position.x==x && data[i].position.y==y){
-            target=i;
-        }
-    }
-    data.erase(data.begin()+target);
-    
-}
 
+
+
+//[TO-DO]gate는 5초 지나면 사라지게 두고, snake의 head를 어떤 함수가 내뱉는 gate의 위치로 옮겨야 함, gate는 snake 출입 중일 때는 사라지면 안됨.
 void GateManager::Update(float eTime){
     int * temp=new int[data.size()];
-    vector<Gate>::iterator iter;
+    vector<CharPosition>::iterator iter;
     
     
     //Gate drop
-    if(eTime-lastDropTime>DROP_INTERVAL){
-        PositionGate("poison",eTime);
-        PositionGate("fruit",eTime);
+    if(eTime-lastDropTime>DROP_GATE_INTERVAL && isEntering==false){
+        for (int i=data.size()-1;i>=0;i--){
+            mapManager->PatchData(data[i].y, data[i].x, '1');
+            data.pop_back();            
+        }
+        PositionGate();
         lastDropTime=eTime;
     }
     
-    for(int i=0;i<data.size();i++){
-        if(isExceedTime(data[i],eTime)){
-            temp[i]=1;
+    // for(int i=0;i<data.size();i++){
+    //     if(isExceedTime(data[i],eTime)){
+    //         temp[i]=1;
             
-        }
-        else{
-            temp[i]=0;
-        }        
-    }
+    //     }
+    //     else{
+    //         temp[i]=0;
+    //     }        
+    // }
     
-    for(int i=data.size()-1;i>=0;i--){
-        if(temp[i]==1){
-            mapManager->PatchData(data[i].position.y, data[i].position.x, '0');
-            data.erase(data.begin()+i);
-        }
-    }
-    
-    delete[] temp;
+    // for(int i=data.size()-1;i>=0;i--){
+    //     if(temp[i]==1){
+    //         mapManager->PatchData(data[i].position.y, data[i].position.x, '0');
+    //         data.erase(data.begin()+i);
+    //     }
+    // }
     
     PushData();
     
 }
 
-void GateManager::PositionGate(std::string check, float eTime)
-{
-    if (check == "fruit"){
-        data.push_back(Gate("fruit",eTime));
-    }
-    else if (check == "poison"){
-        data.push_back(Gate("poison",eTime));
-    }
+void GateManager::PositionGate(){
+    CharPosition temp=getRandPosition();
+    data.push_back(temp);
+    PushData();
+    temp=getRandPosition();
+    data.push_back(temp);
 }
 
 void GateManager::PushData(){
     for (int32 i = 0; i < data.size(); i++){
-        if(data[i].type=="fruit"){
-            mapManager->PatchData(data[i].position.y, data[i].position.x, '5');
-            // mvaddch(data[i].position->y, data[i].position->x,'5');
-        }
-        else if(data[i].type=="poison"){
-            mapManager->PatchData(data[i].position.y, data[i].position.x, '6');
-            // mvaddch(data[i].position->y, data[i].position->x,'5');
-        }
-        else{
-            
-        }
+        mapManager->PatchData(data[i].y, data[i].x, '7');
 	}
 }

--- a/src/GateManager.h
+++ b/src/GateManager.h
@@ -2,27 +2,22 @@
 #include "IObject.h"
 #include "CharPosition.h"
 #include "Snake.h"
-#include "Item.h"
 #include <vector>
 #include <ncurses.h>
 #include <cstdlib>
 #include <string>
 #include <ctime>
 
-class ItemManager : public IObject
+class GateManager : public IObject
 {
 public:
-    int maxheight, maxwidth;
     
-    std::vector<Item> data;
+    std::vector<CharPosition> data;
     
     float lastDropTime=0;
     
-    // Fruit fruit;
-    // Poison poison;
-
-    ItemManager();
-    ~ItemManager();
+    GateManager();
+    ~GateManager();
 
 
     void Render();

--- a/src/GateManager.h
+++ b/src/GateManager.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "IObject.h"
 #include "CharPosition.h"
-#include "Snake.h"
 #include <vector>
 #include <ncurses.h>
 #include <cstdlib>
@@ -13,16 +12,18 @@ class GateManager : public IObject
 public:
     
     std::vector<CharPosition> data;
-    
+    bool isCreated=false;
+    bool isEntering=false;
     float lastDropTime=0;
     
     GateManager();
     ~GateManager();
 
-
+    CharPosition getRandPosition();
     void Render();
+    CharPosition getNextGate();
     void Update(float eTime);
-    void PositionItem(std::string check, float eTime);
+    void PositionGate();
     void DeleteCollisionData(int y, int x);
     
     void PushData();

--- a/src/Item.cpp
+++ b/src/Item.cpp
@@ -23,7 +23,8 @@ CharPosition getRandPosition(){
 
 Item::Item(std::string t,float eTime) : type(t), dropTime(eTime) {
     CharPosition temp=getRandPosition();
-    position=new CharPosition(temp.x,temp.y);
+    position.x=temp.x;
+    position.y=temp.y;
 }
 
 Item::~Item(){

--- a/src/Item.cpp
+++ b/src/Item.cpp
@@ -1,11 +1,10 @@
 #include "Item.h"
 #include "CharPosition.h"
+#include "myFunction.h"
 
-extern int currentWidth;
-extern int currentHeight;
 
 Item::Item(std::string t,float eTime) : type(t), dropTime(eTime) {
-    position=new CharPosition(rand() % (currentWidth / 4 * 3 - 1) + 1, rand() % (currentHeight - 1) + 1);
+    position=new CharPosition(rand() % (WIDTH) + 1, rand() % (HEIGHT) + 1);
 }
 
 Item::~Item(){
@@ -15,10 +14,10 @@ void Item::Update(float eTime){
 }
 
 void Item::Render() {
-    move(position->y,position->x);
+    // move(position->y,position->x);
     
-    if(type=="fruit")
-        addch('$');
-    else if(type=="poison")
-        addch('X');
+    // if(type=="fruit")
+    //     addch('$');
+    // else if(type=="poison")
+    //     addch('X');
 }

--- a/src/Item.cpp
+++ b/src/Item.cpp
@@ -7,7 +7,7 @@
 
 extern MapManager * mapManager;
 
-CharPosition getRandPosition(){
+CharPosition Item::getRandPosition(){
     CharPosition temp;
     while(1){
         int x=rand() % (WIDTH);

--- a/src/Item.cpp
+++ b/src/Item.cpp
@@ -1,10 +1,29 @@
 #include "Item.h"
 #include "CharPosition.h"
 #include "myFunction.h"
+#include "MapManager.h"
 
+
+
+extern MapManager * mapManager;
+
+CharPosition getRandPosition(){
+    CharPosition temp;
+    while(1){
+        int x=rand() % (WIDTH);
+        int y=rand() % (HEIGHT);
+        if(mapManager->data[y][x]=='0'){
+            temp.x=x;
+            temp.y=y;
+            break;
+        }
+    }
+    return temp;
+}
 
 Item::Item(std::string t,float eTime) : type(t), dropTime(eTime) {
-    position=new CharPosition(rand() % (WIDTH) + 1, rand() % (HEIGHT) + 1);
+    CharPosition temp=getRandPosition();
+    position=new CharPosition(temp.x,temp.y);
 }
 
 Item::~Item(){

--- a/src/Item.h
+++ b/src/Item.h
@@ -18,6 +18,9 @@ public:
     
     CharPosition position;
     
+    CharPosition getRandPosition();
+
+    
     // Item(){
     //     int maxwidth, maxheight;
     //     getmaxyx(stdscr, maxheight, maxwidth);

--- a/src/Item.h
+++ b/src/Item.h
@@ -16,7 +16,7 @@ public:
     Item(std::string t, float eTime);
 	~Item();
     
-    CharPosition * position;
+    CharPosition position;
     
     // Item(){
     //     int maxwidth, maxheight;

--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -6,6 +6,9 @@
 #include "ItemManager.h"
 #include "GameScene.h"
 
+extern MapManager * mapManager;
+
+
 
 ItemManager::ItemManager()
 {
@@ -17,50 +20,48 @@ ItemManager::~ItemManager()
 }
 
 void ItemManager::Render(){
-    vector<Item>::iterator iter;
-    for (iter = data.begin(); iter != data.end(); ++iter){
-        (*iter).Render();
+
+}
+
+bool isExceedTime(Item item, float eTime){
+    if(eTime-item.dropTime>5){
+        return true;
     }
+    return false;
 }
 
 void ItemManager::Update(float eTime){
+    int * temp=new int[data.size()];
+    vector<Item>::iterator iter;
+    
+    
+    //item drop
     if(eTime-lastDropTime>DROP_INTERVAL){
         PositionItem("poison",eTime);
         PositionItem("fruit",eTime);
         lastDropTime=eTime;
     }
     
-    // fruit.timeCheck = fruit.timeCheck % 100;
-    // poison.timeCheck = poison.timeCheck % 100;
-
-    // if (fruit.timeCheck == 0)
-    // {
-    //     fruit.Print();
-    //     PositionItem("fruit");
-    // }
-    // else if (fruit.eatFruit)
-    // {
-    //     fruit.timeCheck = 0;
-    //     PositionItem("fruit");
-    //     fruit.eatFruit = false;
-    // }
-    // if (poison.timeCheck == 0)
-    // {
-    //     move(poison.data[0].y, poison.data[0].x);
-    //     addch(' ');
-    //     PositionItem("poison");
-    // }
-    // else if (poison.eatPoison)
-    // {
-    //     poison.timeCheck = 0;
-    //     PositionItem("poison");
-    //     poison.eatPoison = false;
-    // }
-
-    // fruit.timeCheck++;
-    // poison.timeCheck++;
+    for(int i=0;i<data.size();i++){
+        if(isExceedTime(data[i],eTime)){
+            temp[i]=1;
+            
+        }
+        else{
+            temp[i]=0;
+        }        
+    }
     
+    for(int i=data.size()-1;i>=0;i--){
+        if(temp[i]==1){
+            mapManager->PatchData(data[i].position->y, data[i].position->x, '0');
+            data.erase(data.begin()+i);
+        }
+    }
     
+    delete[] temp;
+    
+    PushData();
     
 }
 
@@ -72,6 +73,22 @@ void ItemManager::PositionItem(std::string check, float eTime)
     else if (check == "poison"){
         data.push_back(Item("poison",eTime));
     }
+}
+
+void ItemManager::PushData(){
+    for (int32 i = 0; i < data.size(); i++){
+        if(data[i].type=="fruit"){
+            mapManager->PatchData(data[i].position->y, data[i].position->x, '5');
+            // mvaddch(data[i].position->y, data[i].position->x,'5');
+        }
+        else if(data[i].type=="poison"){
+            mapManager->PatchData(data[i].position->y, data[i].position->x, '6');
+            // mvaddch(data[i].position->y, data[i].position->x,'5');
+        }
+        else{
+            
+        }
+	}
 }
 
 // void ItemManager::GetItem(Snake s)

--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -51,6 +51,7 @@ void ItemManager::Update(float eTime){
     //item drop
     if(eTime-lastDropTime>DROP_INTERVAL){
         PositionItem("poison",eTime);
+        PushData();
         PositionItem("fruit",eTime);
         lastDropTime=eTime;
     }

--- a/src/ItemManager.h
+++ b/src/ItemManager.h
@@ -24,12 +24,14 @@ public:
     ItemManager();
     ~ItemManager();
 
+
     void Render();
     void Update(float eTime);
     void PositionItem(std::string check, float eTime);
     
     
     
+    void PushData();
     void CheckFruit();
     void CheckPoison();
     void CheckGate();

--- a/src/Player.h
+++ b/src/Player.h
@@ -1,0 +1,24 @@
+#pragma once
+
+class Player {
+public:
+    
+    
+    int lengthScore;
+    int growScore;
+    int poisonScore;
+    int gateScore;
+    
+    Player(){
+        
+        lengthScore=0;
+        growScore=0;
+        poisonScore=0;
+        gateScore=0;
+    }
+    ~Player() {}
+    void SetLengthScore(int value) : lengthScore(value){}
+    void SetGrowScore(int value) : growScore(value){}
+    void SetPoisonScore(int value) : poisonScore(value){}
+    void SetGateScore(int value) : gateScore(value){}
+};

--- a/src/Player.h
+++ b/src/Player.h
@@ -17,8 +17,16 @@ public:
         gateScore=0;
     }
     ~Player() {}
-    void SetLengthScore(int value) : lengthScore(value){}
-    void SetGrowScore(int value) : growScore(value){}
-    void SetPoisonScore(int value) : poisonScore(value){}
-    void SetGateScore(int value) : gateScore(value){}
+    void SetLengthScore(int value){
+        lengthScore=value;
+    }
+    void SetGrowScore(int value){
+        growScore=value;
+    }
+    void SetPoisonScore(int value){
+        poisonScore=value;
+    }
+    void SetGateScore(int value){
+        gateScore=value;
+    }
 };

--- a/src/Snake.cpp
+++ b/src/Snake.cpp
@@ -38,6 +38,11 @@ void Snake::initBody()
 	}
 }
 
+
+void Snake::SetDirection(char ch){
+	direction=ch;
+}
+
 void Snake::Update(float eTime){
 	//  ths snake's size below 3. Chanege GameScene to GameOverScene
 	int32 KeyPressed;

--- a/src/Snake.cpp
+++ b/src/Snake.cpp
@@ -48,10 +48,9 @@ void Snake::Update(float eTime){
 	int32 KeyPressed;
 	if (entire.size() < 3 || (entire[0].x <= 0 || entire[0].x >= maxwidth / 4 * 3 - 1) || (entire[0].y >= maxheight - 1 || entire[0].y <= 0))
 	{
-		ChangeScene(new GameOverScene());
+		isDied=true;
 	}
-	if (KeyPressed >= 3)
-		KeyPressed = getch();
+	KeyPressed = getch();
 	switch (KeyPressed)
 	{
 	case KEY_LEFT:
@@ -60,7 +59,7 @@ void Snake::Update(float eTime){
 			direction = 'l';
 		}
 		else
-			ChangeScene(new GameOverScene());
+			isDied=true;
 		break;
 	case KEY_RIGHT:
 		if (direction != 'l')
@@ -68,7 +67,7 @@ void Snake::Update(float eTime){
 			direction = 'r';
 		}
 		else
-			ChangeScene(new GameOverScene());
+			isDied=true;
 		break;
 	case KEY_UP:
 		if (direction != 'd')
@@ -76,7 +75,7 @@ void Snake::Update(float eTime){
 			direction = 'u';
 		}
 		else
-			ChangeScene(new GameOverScene());
+			isDied=true;
 		break;
 	case KEY_DOWN:
 		if (direction != 'u')
@@ -84,7 +83,7 @@ void Snake::Update(float eTime){
 			direction = 'd';
 		}
 		else
-			ChangeScene(new GameOverScene());
+			isDied=true;
 		break;
 	case KEY_BACKSPACE:
 		direction = 'q'; // key to quit the game
@@ -93,31 +92,45 @@ void Snake::Update(float eTime){
 
 	// the snake moves and we add an extra character at the beginning of the vector
 	// add a head and initialise new coordinates for CharPosition according to the direction input
-	if (direction == 'l')
-	{
-		entire.insert(entire.begin(), CharPosition(entire[0].x - 1, entire[0].y));
-	}
-	else if (direction == 'r')
-	{
-		entire.insert(entire.begin(), CharPosition(entire[0].x + 1, entire[0].y));
-	}
-	else if (direction == 'u')
-	{
-		entire.insert(entire.begin(), CharPosition(entire[0].x, entire[0].y - 1));
-	}
-	else if (direction == 'd')
-	{
-		entire.insert(entire.begin(), CharPosition(entire[0].x, entire[0].y + 1));
-	}
-    
-    //isGrow는 false일 때 entire 벡터에 갱신된 head가 추가되면 맨 뒤에 있는 entire 원소 제거
-    if(isGrow==false){
-        CutTail();
+    if(isDied==false){
+	    if (direction == 'l')
+	    {
+	    	entire.insert(entire.begin(), CharPosition(entire[0].x - 1, entire[0].y));
+	    }
+	    else if (direction == 'r')
+	    {
+	    	entire.insert(entire.begin(), CharPosition(entire[0].x + 1, entire[0].y));
+	    }
+	    else if (direction == 'u')
+	    {
+	    	entire.insert(entire.begin(), CharPosition(entire[0].x, entire[0].y - 1));
+	    }
+	    else if (direction == 'd')
+	    {
+	    	entire.insert(entire.begin(), CharPosition(entire[0].x, entire[0].y + 1));
+	    }
+        //isGrow는 false일 때 entire 벡터에 갱신된 head가 추가되면 맨 뒤에 있는 entire 원소 제거
+        if(isGrow==false){
+            CutTail();
+        }
+        else{
+            isGrow=false;
+        }
+        
+        PushData();
     }
 
-	
-    PushData();
 }
+
+bool Snake::IsCollision(){
+    CharPosition head=GetHead();
+    if(mapManager->data[head.y][head.x]!=0){
+        return true;
+    }
+    return false;
+}
+
+
 
 void Snake::CutTail(){
     mapManager->PatchData(entire[entire.size() - 1].y, entire[entire.size() - 1].x,'0');
@@ -131,6 +144,10 @@ void Snake::Grow(){
 void Snake::Shrink(){
     isShrink=true;
     CutTail();
+}
+
+CharPosition Snake::GetHead(){
+    return entire[0];
 }
 
 

--- a/src/Snake.h
+++ b/src/Snake.h
@@ -16,6 +16,7 @@ public:
 	~Snake();
 
 	std::vector<CharPosition> entire;
+    bool isDied=false;
 	char partchar, direction;
 	int choiceCount;
 	int select;
@@ -27,15 +28,21 @@ public:
     
     void PushData();
     
-    void SetDirection();
+    void SetDirection(char ch);
+    
+    bool IsCollision();
     
     void Grow();
     void Shrink();
+    
+    CharPosition GetHead();
     
     void CutTail();
     
 	void Render();
 	void initBody();
+    
+    
     
 	void EatItem(bool fruit, bool poison);
 };

--- a/src/Snake.h
+++ b/src/Snake.h
@@ -27,6 +27,8 @@ public:
     
     void PushData();
     
+    void SetDirection();
+    
     void Grow();
     void Shrink();
     

--- a/src/myFunction.h
+++ b/src/myFunction.h
@@ -4,6 +4,8 @@
 #include <iostream>
 
 #define DROP_INTERVAL 3.0f
+#define DROP_GATE_INTERVAL 7.0f
+
 #define WIDTH 62
 #define HEIGHT 32
 


### PR DESCRIPTION
Changes proposed in this pull request:
* Gate를 rendering 하게 해줬음.
* ItemManager를 개편하여 배열 index를 벗어나는 오류를 범하지 않도록 함
* Snake head 좌표와 Map의 좌표를 비교하여 head좌표가 gate, poison, fruit의 좌표일 경우 각각 처리하도록 하였음
#### **`GameScene.cpp`**
```c++
void GameScene::ProcessCollision(){
    int y=snake->GetHead().y;
    int x=snake->GetHead().x;
    switch(mapManager->data[y][x]){
          case '5':
            itemManager->DeleteCollisionData(y, x);
            snake->Grow();
            break;
          case '6':
            itemManager->DeleteCollisionData(y, x);
            snake->Shrink();
            break;
          case '7':
            break;
    }
}
```