### PR TITLE
[Feature/scoreboard] Add scoreBoardView

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 all:
-	g++ src/GameScene.cpp src/GameOverScene.cpp src/Snake.cpp src/Stage.cpp src/myFunction.cpp src/ItemManager.cpp src/MapManager.cpp src/WaitingScene.cpp src/GateManager.cpp src/Item.cpp src/main.cpp -lncurses -o /tmp/a.out && /tmp/a.out
+	g++ src/GameScene.cpp src/GameOverScene.cpp src/Snake.cpp src/Stage.cpp src/myFunction.cpp src/ItemManager.cpp src/MapManager.cpp src/WaitingScene.cpp src/GateManager.cpp src/Format.cpp src/Item.cpp src/main.cpp -lncurses -o /tmp/a.out && /tmp/a.out

--- a/src/Format.cpp
+++ b/src/Format.cpp
@@ -1,0 +1,58 @@
+#include <ncurses.h>
+#include <vector>
+#include <cstdlib>
+#include "Player.h"
+#include "Stage.h"
+#include "Format.h"
+
+extern Player * player;
+extern Stage * stage;
+
+
+//char edgechar = (char)219;
+// for (int i = maxwidth / 4 * 3; i < maxwidth; i++)
+// {
+//     move(0, i);
+//     addch(edgechar);
+// }
+// for (int i = maxwidth / 4 * 3; i < maxwidth; i++)
+// {
+//     move(maxheight / 2, i);
+//     addch(edgechar);
+// }
+// for (int i = maxwidth / 4 * 3; i < maxwidth; i++)
+// {
+//     move(maxheight - 1, i);
+//     addch(edgechar);
+// }
+// for (int i = 0; i < maxheight; i++)
+// {
+//     move(i, maxwidth - 1);
+//     addch(edgechar);
+// }
+
+Format::Format(){
+    
+    //굳이 maxwidth, maxheight 안써도 됩니다.
+    getmaxyx(stdscr, maxheight, maxwidth);
+    move(0, maxwidth / 5 * 4 + 4);
+    printw("< S C O R E >");
+    move(maxheight / 2, maxwidth / 5 * 4 + 2);
+    printw("< M I S S I O N >");
+}
+Format::~Format(){
+    
+}
+
+void Format::Update(float eTime){
+    
+}
+
+void Format::Render(){
+    //[TO-DO] 여기에서 mvaddch를 이용해서 출력해주기
+    int * nowMission=stage->getNowMission();
+    
+    move(3, maxwidth / 5 * 4 + 4);
+    printw("Length : %d/%d", player->lengthScore, nowMission[0]);
+    
+}

--- a/src/Format.h
+++ b/src/Format.h
@@ -2,44 +2,16 @@
 #include <ncurses.h>
 #include <vector>
 #include <cstdlib>
-#include "IScene.h"
+#include "IObject.h"
 
-class Format : public IScene
+class Format : public IObject
 {
 public:
-    char edgechar = (char)219;
 
-    Format()
-    {
-        int maxwidth, maxheight;
-        getmaxyx(stdscr, maxheight, maxwidth);
-        for (int i = maxwidth / 4 * 3; i < maxwidth; i++)
-        {
-            move(0, i);
-            addch(edgechar);
-        }
-        for (int i = maxwidth / 4 * 3; i < maxwidth; i++)
-        {
-            move(maxheight / 2, i);
-            addch(edgechar);
-        }
-        for (int i = maxwidth / 4 * 3; i < maxwidth; i++)
-        {
-            move(maxheight - 1, i);
-            addch(edgechar);
-        }
-        for (int i = 0; i < maxheight; i++)
-        {
-            move(i, maxwidth - 1);
-            addch(edgechar);
-        }
-        move(0, maxwidth / 5 * 4 + 4);
-        printw("< S C O R E >");
-        move(maxheight / 2, maxwidth / 5 * 4 + 2);
-        printw("< M I S S I O N >");
-    }
-    ~Format() {}
-    void Print() {}
-    void Update(float eTime) {}
-    void Render() {}
+    int maxheight, maxwidth;
+
+    Format();
+    ~Format();
+    void Update(float eTime);
+    void Render();
 };

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -39,7 +39,7 @@ GameScene::GameScene()
     
     
     
-    // format = new Format();
+    format = new Format();
 
 
 	InitGameWindow();
@@ -74,54 +74,45 @@ void GameScene::ProcessCollision(){
     
     char temp=mapManager->data[y][x];
     
-    mvaddch(2, maxwidth / 5 * 4 + 4, mapManager->data[y][x]);
+    // mvaddch(2, maxwidth / 5 * 4 + 4, mapManager->data[y][x]);
     
     if(temp=='1'){
         snake->isDied=true;
     }
     else if(temp=='5'){
         itemManager->DeleteCollisionData(y, x);
+        player->growScore+=1;
         snake->Grow();        
     }
     else if(temp=='6'){
         itemManager->DeleteCollisionData(y, x);
+        player->poisonScore+=1;
         snake->Shrink();
     }
     else if(temp=='7'){
         CharPosition nextGate=gateManager->GetNextGate();
+        player->gateScore+=1;
         gateManager->isUsed=true;
         snake->SetHeadPos(nextGate.y, nextGate.x);
     }    
-    
-    // switch(){
-    //     case '1':
-    //         snake->isDied=true;
-    //         break;
-    //     case '5':{
+  
+}
 
-    //         break;            
-    //     }
-    //     case '6':
 
-    //         break;
-    //     case '7' : {
-
-    //         break;
-    //     }
-    //     default:
-    //         mvaddch(2, maxwidth / 5 * 4 + 4, mapManager->data[y][x]);
-    //         break;
-    // }
+bool isClear(){
+    //여기에서 스테이지 클리어 조건 걸어주고
+    return false;
 }
 
 
 
-void GameScene::Update(float eTime)
-{
-	// stage->Update(eTime);
-
+void GameScene::Update(float eTime){
+    //여기에서 chagneScene을 걸어준다.
+    if(isClear()){
+        ChangeScene(new GameScene());
+        stage->nowStage++;
+    }
     
-
     
     player->SetLengthScore(snake->entire.size());
     
@@ -137,14 +128,7 @@ void GameScene::Update(float eTime)
 
 	itemManager->Update(eTime);
 	gateManager->Update(eTime);
-
-
     
-    
-    
-	// itemManager->GetItem(*snake);
-	// snake->EatItem(itemManager->getEatFruit(), itemManager->getEatPoison());
-
 	//* float eTime test code *//
 	// move((maxheight-2)/2,(maxwidth-5)/2);
 	// printw("%f",eTime);
@@ -152,9 +136,8 @@ void GameScene::Update(float eTime)
 }
 
 void GameScene::Render(){
+    format->Render();
     
-    mvaddch(0, maxwidth / 5 * 4 + 4, (char)(player->lengthScore+48));
-    // char (*data)[WIDTH]=(char(*)[WIDTH])mapManager->GetData();
     for(int i = 0; i < HEIGHT; i++){
       for(int j = 0; j < WIDTH; j++){
         switch(mapManager->data[i][j]){
@@ -187,6 +170,9 @@ void GameScene::Render(){
           }
      }
    }
+    
+    
+    
     refresh();
 }
 

--- a/src/MapManager.cpp
+++ b/src/MapManager.cpp
@@ -14,7 +14,7 @@ void MapManager::Load(){
     
     
     std::ifstream readFile;
-    string src = "map/map"+std::to_string(stage->getNowStage()) + ".txt";
+    string src = "map/map"+std::to_string(stage->getNowStage()+1) + ".txt";
     // string src = "map/map1.txt";
 
     readFile.open(src);

--- a/src/Stage.cpp
+++ b/src/Stage.cpp
@@ -10,66 +10,9 @@ Stage::Stage(){
 Stage::~Stage(){
 }
 
+
 void Stage::Update(float eTime){
-    
-    if(clear){
-        refresh();
-        clear=false;
-    }
-	// if (nowStage == hippoStage[0])
-	// {
-	// 	for (int j = 0; j < hippoCount[0]; j++)
-	// 	{
-	// 		hippo[j]->Update(eTime);
-	// 	}
-	// }
-	// if (nowStage == 5) { footHold->pos.y = stageRect[5][4].top - 400; }
-	// if (nowStage == 6) { bossHippoAni->Update(eTime); }
-	// if (nowStage == 6 && isStage7Button[0] && isStage7Button[1] && isStage7Button[2])
-	// {
-	// 	clear = 1;
-	// }
-	// if (clear)
-	// {
-	// 	if (stage7FootHold->pos.y  < 300)
-	// 	{
-	// 		stage7FootHold->pos.y += 50 * eTime;
-	// 		bossHippoAni->pos.y += 50 * eTime;
-	// 	}
-	// 	else
-	// 	{
-	// 		clear = 2;
-	// 		state = Clear;
-	// 		sound->Stop(INGAME_BGM);
-	// 		sound->Stop(BOSS_BGM);
-	// 		sound->Play(CLEAR_BGM);
-	// 	}
-	// }
 }
 
 void Stage::Render() {
-    
-    
-	// sky[0]->Render(&this->mat);
-
-	// for (int i = 0; i < 2; i++)
-	// {
-	// 	if (nowStage == hippoStage[i])
-	// 	{
-	// 		for (int j = 0; j < hippoCount[i]; j++)
-	// 		{
-	// 			hippo[j]->Render(&this->mat);
-	// 		}
-	// 	}
-	// }
-
-	// if (nowStage == 5)
-	// {
-	// 	footHold->Render(&this->mat);
-	// }
-	// if (nowStage == 6)
-	// {
-	// 	stage7FootHold->Render(&this->mat);
-	// 	bossHippoAni->Render(&this->mat);
-	// }
 }

--- a/src/Stage.h
+++ b/src/Stage.h
@@ -6,16 +6,24 @@ class Stage : public IObject
 public:
 	int nowStage;
 	bool clear;
+    
+    //mission 배열 (뱀 길이, grow 아이템, poison 아이템, gate 아이템)
+    int mission[3][4] = {
+        {6,2,2,2},
+        {6,2,2,2},
+        {6,2,2,2},
+    };
+    
 	Stage();
 	~Stage();
 
 	int getNowStage() { return nowStage; }
-
-	void setNowStage(int nowStage)
-	{
-		this->nowStage = nowStage;
-	}
+    
+    int * getNowMission() { return mission[nowStage]; }
+    
+	void setNowStage(int nowStage) { this->nowStage = nowStage; }
 
 	void Update(float eTime);
+    
 	void Render();
 };

--- a/src/WaitingScene.cpp
+++ b/src/WaitingScene.cpp
@@ -23,7 +23,7 @@ WaitingScene::~WaitingScene()
 void WaitingScene::Update(float eTime)
 {
     char answer = IsUserReady();
-    stage->setNowStage((int)answer-48);
+    stage->setNowStage((int)answer-49);
     
     if (answer == 'n')
         exit(0);


### PR DESCRIPTION
Changes proposed in this pull request:
* ScoreBoard를 추가했습니다.
* Stage 에서는 mission이라는 배열을 선언했는데 배열 하나당 (뱀 길이, grow 아이템, poison 아이템, gate 아이템) 이렇게 구성되어 있습니다. 이 조건을 모두 충족시키면 stage clear 사인을 GameScene에서 판단하여 처리합니다.
#### **`GameScene.cpp`**
``` c++

bool isClear(){
    //여기에서 스테이지 클리어 조건 걸어주고
    return false;
}

void GameScene::Update(float eTime){
    //여기에서 chagneScene을 걸어준다.
    if(isClear()){
        ChangeScene(new GameScene());
        stage->nowStage++;
    }
```
* Format 클래스는 GameScene에서 동적할당하여 GameScene 내의 Render()에서 format->Render() 돌려줌으로써 score가 렌더링됩니다. Format 클래스 확인하세요. **TO-DO에는 mvaddch를 활용하라고 써놨지만 그것이 아니라 move후에 printw로 출력해주는 게 더 편할 듯합니다.** 여기에 완료된 미션은 (V) 표시해주시면 됩니다. nowMission 배열을 활용하세요. 이것은 Stage 클래스에서 nowStage에 맞는 mission 배열입니다.
#### **`Format.cpp`**
```c++
void Format::Render(){
    //[TO-DO] 여기에서 mvaddch를 이용해서 출력해주기
    int * nowMission=stage->getNowMission();
    
    move(3, maxwidth / 5 * 4 + 4);
    printw("Length : %d/%d", player->lengthScore, nowMission[0]);
    
}
```